### PR TITLE
Fix mall URL to javascript file

### DIFF
--- a/Application/Factory.php
+++ b/Application/Factory.php
@@ -46,7 +46,7 @@ class Factory
             Registry::getConfig()->getOutDir(),
             'oeecondaanalytics',
             EmosFileData::TRACKING_CODE_FILE_NAME,
-            Registry::getConfig()->getOutUrl(),
+            Registry::getConfig()->getOutUrl(null, null, true),
             ShopIdCalculator::BASE_SHOP_ID
         );
     }


### PR DESCRIPTION
Bugfix: JsFileLocator always generates URL to emos.js with the main shop domain instead of the active shop domain.