### PR TITLE
Fixed shop crash on startup when no key is set in config file and 'st…

### DIFF
--- a/Application/Core/ViewConfig.php
+++ b/Application/Core/ViewConfig.php
@@ -26,6 +26,6 @@ class ViewConfig extends ViewConfig_parent
     public function oeEcondaAnalyticsShowTrackingNote(): string
     {
         $config = \OxidEsales\Eshop\Core\Registry::getConfig();
-        return $config->getConfigParam('sOeEcondaAnalyticsTrackingShowNote');
+        return $config->getConfigParam('sOeEcondaAnalyticsTrackingShowNote') ?? '';
     }
 }


### PR DESCRIPTION
…rict_types=1' is enabled

A very minor fix, but an important one: by using :string as a return value, PHP will throw a TypeError when the strict_types=1 directive is enabled. By using the null coalescent operator, I return an empty string instead of null, avoiding a shop crash.

In theory, you could use :?string which would allow NULL as a returnable type, but that's only available in PHP 7.1. To ensure compatibility with PHP 7.0, I used the null coalescent operator instead.